### PR TITLE
Different source archive and backwards compatibility for EL7

### DIFF
--- a/0001-Make-Salsa20-optional-if-building-against-older-libg.patch
+++ b/0001-Make-Salsa20-optional-if-building-against-older-libg.patch
@@ -1,0 +1,46 @@
+From dc5de5699d9d637baaee6e0f71f4de9046e4a0fc Mon Sep 17 00:00:00 2001
+From: Toni Spets <toni.spets@iki.fi>
+Date: Sat, 18 Feb 2017 10:54:06 +0200
+Subject: [PATCH] Make Salsa20 optional if building against older libgcrypt
+
+---
+ src/crypto/Crypto.cpp                | 2 ++
+ src/crypto/SymmetricCipherGcrypt.cpp | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/src/crypto/Crypto.cpp b/src/crypto/Crypto.cpp
+index d00be72..9ebd2e5 100644
+--- a/src/crypto/Crypto.cpp
++++ b/src/crypto/Crypto.cpp
+@@ -90,11 +90,13 @@ bool Crypto::checkAlgorithms()
+         qWarning("Crypto::checkAlgorithms: %s", qPrintable(m_errorStr));
+         return false;
+     }
++#if GCRYPT_VERSION_NUMBER >= 0x010600
+     if (gcry_cipher_algo_info(GCRY_CIPHER_SALSA20, GCRYCTL_TEST_ALGO, nullptr, nullptr) != 0) {
+         m_errorStr = "GCRY_CIPHER_SALSA20 not found.";
+         qWarning("Crypto::checkAlgorithms: %s", qPrintable(m_errorStr));
+         return false;
+     }
++#endif
+     if (gcry_md_test_algo(GCRY_MD_SHA256) != 0) {
+         m_errorStr = "GCRY_MD_SHA256 not found.";
+         qWarning("Crypto::checkAlgorithms: %s", qPrintable(m_errorStr));
+diff --git a/src/crypto/SymmetricCipherGcrypt.cpp b/src/crypto/SymmetricCipherGcrypt.cpp
+index cd43240..7f22caa 100644
+--- a/src/crypto/SymmetricCipherGcrypt.cpp
++++ b/src/crypto/SymmetricCipherGcrypt.cpp
+@@ -44,8 +44,10 @@ int SymmetricCipherGcrypt::gcryptAlgo(SymmetricCipher::Algorithm algo)
+     case SymmetricCipher::Twofish:
+         return GCRY_CIPHER_TWOFISH;
+ 
++#if GCRYPT_VERSION_NUMBER >= 0x010600
+     case SymmetricCipher::Salsa20:
+         return GCRY_CIPHER_SALSA20;
++#endif
+ 
+     default:
+         Q_ASSERT(false);
+-- 
+2.9.3
+

--- a/keepassxc.spec
+++ b/keepassxc.spec
@@ -1,11 +1,12 @@
 Name: keepassxc
 Version: 2.1.2
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: Cross-platform password manager
 Group: User Interface/Desktops
 License: GPLv2+
 URL: https://keepassxreboot.github.io/
-Source0:https://github.com/keepassxreboot/keepassxc/archive/%{name}-%{version}.tar.gz
+Source0: https://github.com/keepassxreboot/keepassxc/releases/download/%{version}/keepassxc-%{version}-src.tar.xz
+Patch0: 0001-Make-Salsa20-optional-if-building-against-older-libg.patch
 BuildRequires: qt5-qtbase-devel > 5.1
 BuildRequires: qt5-linguist
 BuildRequires: libXtst-devel
@@ -35,6 +36,8 @@ KeePassXC is a community fork of KeePassX, the cross-platform port of KeePass fo
  
 %prep
 %setup -qn %{name}-%{version}
+
+%patch0 -p1
 
 %build
 mkdir build
@@ -107,6 +110,10 @@ desktop-file-validate %{_datadir}/applications/keepassxc.desktop &> /dev/null ||
 %{_libdir}/keepassxc/*.so
  
 %changelog
+* Sat Feb 18 2017 Toni Spets - 2.1.2-4
+- Use official src.tar.xz archive with publicly verifiable digest
+- Add backwards compatibility for EL7
+
 * Fri Feb 17 2017 Bugzy Little <bugzylittle@gmail.com> - 2.1.2
 - Fix conflict with keepassx by renaming mime
 


### PR DESCRIPTION
Enough to build for EL7. You can enable EPEL 7 as a build target for the copr repository.

Don't know the exact implications of patching out Salsa20 support like this, though.